### PR TITLE
docs: fix broken crate documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ of Raft.
 
 This project was created as an exercise in implementing and learning about distributed systems. **Do NOT use this in production.**
 
-- [Crate Documentation](https://jzhao.xyz/miniraft/miniraft)
+- [Crate Documentation](https://jackyzha0.github.io/miniraft/miniraft/)
 - [Specification](https://raft.github.io/raft.pdf)


### PR DESCRIPTION
## Summary
The Crate Documentation link in the README was pointing to a broken URL (https://jzhao.xyz/miniraft/miniraft) which returns a 404.

## Changes
- Updated the link to the working GitHub Pages URL: https://jackyzha0.github.io/miniraft/miniraft/

Fixes #3